### PR TITLE
Improve sleep duration UI

### DIFF
--- a/docs/apps/lidarr.html
+++ b/docs/apps/lidarr.html
@@ -147,7 +147,7 @@
                 </tr>
                 <tr>
                     <td>Sleep Duration</td>
-                    <td>Time in seconds between processing cycles</td>
+                    <td>Time between processing cycles</td>
                     <td>1800 (30 min)</td>
                     <td>Music indexers often have stricter limits</td>
                 </tr>

--- a/docs/apps/radarr.html
+++ b/docs/apps/radarr.html
@@ -145,7 +145,7 @@
                 </tr>
                 <tr>
                     <td>Sleep Duration</td>
-                    <td>Time in seconds between processing cycles</td>
+                    <td>Time between processing cycles</td>
                     <td>1200 (20 min)</td>
                     <td>Longer intervals reduce indexer load</td>
                 </tr>

--- a/docs/apps/readarr.html
+++ b/docs/apps/readarr.html
@@ -147,7 +147,7 @@
                 </tr>
                 <tr>
                     <td>Sleep Duration</td>
-                    <td>Time in seconds between processing cycles</td>
+                    <td>Time between processing cycles</td>
                     <td>2400 (40 min)</td>
                     <td>Book indexers often have limited content</td>
                 </tr>

--- a/docs/apps/sonarr.html
+++ b/docs/apps/sonarr.html
@@ -154,7 +154,7 @@
                 </tr>
                 <tr>
                     <td>Sleep Duration</td>
-                    <td>Time in seconds between processing cycles</td>
+                    <td>Time between processing cycles</td>
                     <td>900 (15 min)</td>
                     <td>Longer intervals reduce indexer load</td>
                 </tr>

--- a/docs/apps/whisparr-v2.html
+++ b/docs/apps/whisparr-v2.html
@@ -151,7 +151,7 @@
                 </tr>
                 <tr>
                     <td>Sleep Duration</td>
-                    <td>Time in seconds between processing cycles</td>
+                    <td>Time between processing cycles</td>
                     <td>3600 (60 min)</td>
                     <td>Adult indexers often have strict limits</td>
                 </tr>

--- a/docs/apps/whisparr-v3.html
+++ b/docs/apps/whisparr-v3.html
@@ -153,7 +153,7 @@
                 </tr>
                 <tr>
                     <td>Sleep Duration</td>
-                    <td>Time in seconds between processing cycles</td>
+                    <td>Time between processing cycles</td>
                     <td>3600 (60 min)</td>
                     <td>Adult indexers often have strict limits</td>
                 </tr>

--- a/docs/faq.html
+++ b/docs/faq.html
@@ -184,7 +184,7 @@
                     <div class="faq-answer">
                         In the web interface settings, you can configure:
                         <ul>
-                            <li><strong>Sleep Duration:</strong> Time between search cycles (default: 900 seconds)</li>
+                            <li><strong>Sleep Duration:</strong> Time between search cycles (default: 15 minutes)</li>
                             <li><strong>Hunt Missing:</strong> Number of missing items to search per cycle</li>
                             <li><strong>Hunt Upgrades:</strong> Number of upgrade searches per cycle</li>
                             <li><strong>Minimum Download Queue Size:</strong> Pause searching when queue exceeds this number</li>

--- a/frontend/static/js/settings_forms.js
+++ b/frontend/static/js/settings_forms.js
@@ -112,8 +112,13 @@ const SettingsForms = {
                 </div>
                 <div class="setting-item">
                     <label for="sonarr_sleep_duration"><a href="/Huntarr.io/docs/#/configuration?id=sleep-duration" class="info-icon" title="Learn more about sleep duration" target="_blank" rel="noopener"><i class="fas fa-info-circle"></i></a>Sleep Duration:</label>
-                    <input type="number" id="sonarr_sleep_duration" name="sleep_duration" min="60" value="${settings.sleep_duration !== undefined ? settings.sleep_duration : 900}">
-                    <p class="setting-help">Time in seconds between processing cycles</p>
+                    <input type="number" id="sonarr_sleep_duration" min="1" value="${(SettingsForms.secondsToValueUnit(settings.sleep_duration !== undefined ? settings.sleep_duration : 900)).value}">
+                    <select id="sonarr_sleep_duration_unit">
+                        <option value="minutes" ${SettingsForms.secondsToValueUnit(settings.sleep_duration !== undefined ? settings.sleep_duration : 900).unit === 'minutes' ? 'selected' : ''}>Minutes</option>
+                        <option value="hours" ${SettingsForms.secondsToValueUnit(settings.sleep_duration !== undefined ? settings.sleep_duration : 900).unit === 'hours' ? 'selected' : ''}>Hours</option>
+                        <option value="days" ${SettingsForms.secondsToValueUnit(settings.sleep_duration !== undefined ? settings.sleep_duration : 900).unit === 'days' ? 'selected' : ''}>Days</option>
+                    </select>
+                    <p class="setting-help">Time between processing cycles</p>
                 </div>
                 <div class="setting-item">
                     <label for="sonarr_hourly_cap"><a href="#" class="info-icon" title="Maximum API requests per hour for this app" target="_blank" rel="noopener"><i class="fas fa-info-circle"></i></a>API Cap - Hourly:</label>
@@ -275,8 +280,13 @@ const SettingsForms = {
                 </div>
                 <div class="setting-item">
                     <label for="radarr_sleep_duration"><a href="/Huntarr.io/docs/#/configuration?id=sleep-duration" class="info-icon" title="Learn more about sleep duration" target="_blank" rel="noopener"><i class="fas fa-info-circle"></i></a>Sleep Duration:</label>
-                    <input type="number" id="radarr_sleep_duration" name="sleep_duration" min="60" value="${settings.sleep_duration !== undefined ? settings.sleep_duration : 900}">
-                    <p class="setting-help">Time in seconds between processing cycles</p>
+                    <input type="number" id="radarr_sleep_duration" min="1" value="${(SettingsForms.secondsToValueUnit(settings.sleep_duration !== undefined ? settings.sleep_duration : 900)).value}">
+                    <select id="radarr_sleep_duration_unit">
+                        <option value="minutes" ${SettingsForms.secondsToValueUnit(settings.sleep_duration !== undefined ? settings.sleep_duration : 900).unit === 'minutes' ? 'selected' : ''}>Minutes</option>
+                        <option value="hours" ${SettingsForms.secondsToValueUnit(settings.sleep_duration !== undefined ? settings.sleep_duration : 900).unit === 'hours' ? 'selected' : ''}>Hours</option>
+                        <option value="days" ${SettingsForms.secondsToValueUnit(settings.sleep_duration !== undefined ? settings.sleep_duration : 900).unit === 'days' ? 'selected' : ''}>Days</option>
+                    </select>
+                    <p class="setting-help">Time between processing cycles</p>
                 </div>
                 <div class="setting-item">
                     <label for="radarr_hourly_cap"><a href="#" class="info-icon" title="Maximum API requests per hour for this app" target="_blank" rel="noopener"><i class="fas fa-info-circle"></i></a>API Cap - Hourly:</label>
@@ -444,8 +454,13 @@ const SettingsForms = {
                 </div>
                 <div class="setting-item">
                     <label for="lidarr_sleep_duration"><a href="/Huntarr.io/docs/#/configuration?id=sleep-duration" class="info-icon" title="Learn more about sleep duration" target="_blank" rel="noopener"><i class="fas fa-info-circle"></i></a>Sleep Duration:</label>
-                    <input type="number" id="lidarr_sleep_duration" name="sleep_duration" min="60" value="${settings.sleep_duration !== undefined ? settings.sleep_duration : 900}">
-                    <p class="setting-help">Time in seconds between processing cycles</p>
+                    <input type="number" id="lidarr_sleep_duration" min="1" value="${(SettingsForms.secondsToValueUnit(settings.sleep_duration !== undefined ? settings.sleep_duration : 900)).value}">
+                    <select id="lidarr_sleep_duration_unit">
+                        <option value="minutes" ${SettingsForms.secondsToValueUnit(settings.sleep_duration !== undefined ? settings.sleep_duration : 900).unit === 'minutes' ? 'selected' : ''}>Minutes</option>
+                        <option value="hours" ${SettingsForms.secondsToValueUnit(settings.sleep_duration !== undefined ? settings.sleep_duration : 900).unit === 'hours' ? 'selected' : ''}>Hours</option>
+                        <option value="days" ${SettingsForms.secondsToValueUnit(settings.sleep_duration !== undefined ? settings.sleep_duration : 900).unit === 'days' ? 'selected' : ''}>Days</option>
+                    </select>
+                    <p class="setting-help">Time between processing cycles</p>
                 </div>
                 <div class="setting-item">
                     <label for="lidarr_hourly_cap"><a href="#" class="info-icon" title="Maximum API requests per hour for this app" target="_blank" rel="noopener"><i class="fas fa-info-circle"></i></a>API Cap - Hourly:</label>
@@ -579,8 +594,13 @@ const SettingsForms = {
                 </div>
                 <div class="setting-item">
                     <label for="readarr_sleep_duration"><a href="/Huntarr.io/docs/#/configuration?id=sleep-duration" class="info-icon" title="Learn more about sleep duration" target="_blank" rel="noopener"><i class="fas fa-info-circle"></i></a>Sleep Duration:</label>
-                    <input type="number" id="readarr_sleep_duration" name="sleep_duration" min="60" value="${settings.sleep_duration !== undefined ? settings.sleep_duration : 900}">
-                    <p class="setting-help">Time in seconds between processing cycles</p>
+                    <input type="number" id="readarr_sleep_duration" min="1" value="${(SettingsForms.secondsToValueUnit(settings.sleep_duration !== undefined ? settings.sleep_duration : 900)).value}">
+                    <select id="readarr_sleep_duration_unit">
+                        <option value="minutes" ${SettingsForms.secondsToValueUnit(settings.sleep_duration !== undefined ? settings.sleep_duration : 900).unit === 'minutes' ? 'selected' : ''}>Minutes</option>
+                        <option value="hours" ${SettingsForms.secondsToValueUnit(settings.sleep_duration !== undefined ? settings.sleep_duration : 900).unit === 'hours' ? 'selected' : ''}>Hours</option>
+                        <option value="days" ${SettingsForms.secondsToValueUnit(settings.sleep_duration !== undefined ? settings.sleep_duration : 900).unit === 'days' ? 'selected' : ''}>Days</option>
+                    </select>
+                    <p class="setting-help">Time between processing cycles</p>
                 </div>
                 <div class="setting-item">
                     <label for="readarr_hourly_cap"><a href="#" class="info-icon" title="Maximum API requests per hour for this app" target="_blank" rel="noopener"><i class="fas fa-info-circle"></i></a>API Cap - Hourly:</label>
@@ -712,8 +732,13 @@ const SettingsForms = {
                 </div>
                 <div class="setting-item">
                     <label for="whisparr_sleep_duration"><a href="/Huntarr.io/docs/#/configuration?id=sleep-duration" class="info-icon" title="Learn more about sleep duration" target="_blank" rel="noopener"><i class="fas fa-info-circle"></i></a>Sleep Duration:</label>
-                    <input type="number" id="whisparr_sleep_duration" name="sleep_duration" min="60" value="${settings.sleep_duration !== undefined ? settings.sleep_duration : 900}">
-                    <p class="setting-help">Time in seconds between processing cycles</p>
+                    <input type="number" id="whisparr_sleep_duration" min="1" value="${(SettingsForms.secondsToValueUnit(settings.sleep_duration !== undefined ? settings.sleep_duration : 900)).value}">
+                    <select id="whisparr_sleep_duration_unit">
+                        <option value="minutes" ${SettingsForms.secondsToValueUnit(settings.sleep_duration !== undefined ? settings.sleep_duration : 900).unit === 'minutes' ? 'selected' : ''}>Minutes</option>
+                        <option value="hours" ${SettingsForms.secondsToValueUnit(settings.sleep_duration !== undefined ? settings.sleep_duration : 900).unit === 'hours' ? 'selected' : ''}>Hours</option>
+                        <option value="days" ${SettingsForms.secondsToValueUnit(settings.sleep_duration !== undefined ? settings.sleep_duration : 900).unit === 'days' ? 'selected' : ''}>Days</option>
+                    </select>
+                    <p class="setting-help">Time between processing cycles</p>
                 </div>
                 <div class="setting-item">
                     <label for="whisparr_hourly_cap"><a href="#" class="info-icon" title="Maximum API requests per hour for this app" target="_blank" rel="noopener"><i class="fas fa-info-circle"></i></a>API Cap - Hourly:</label>
@@ -859,8 +884,13 @@ const SettingsForms = {
                 </div>
                 <div class="setting-item">
                     <label for="eros_sleep_duration"><a href="/Huntarr.io/docs/#/configuration?id=sleep-duration" class="info-icon" title="Learn more about sleep duration" target="_blank" rel="noopener"><i class="fas fa-info-circle"></i></a>Sleep Duration:</label>
-                    <input type="number" id="eros_sleep_duration" name="sleep_duration" min="60" value="${settings.sleep_duration !== undefined ? settings.sleep_duration : 900}">
-                    <p class="setting-help">Time in seconds between processing cycles</p>
+                    <input type="number" id="eros_sleep_duration" min="1" value="${(SettingsForms.secondsToValueUnit(settings.sleep_duration !== undefined ? settings.sleep_duration : 900)).value}">
+                    <select id="eros_sleep_duration_unit">
+                        <option value="minutes" ${SettingsForms.secondsToValueUnit(settings.sleep_duration !== undefined ? settings.sleep_duration : 900).unit === 'minutes' ? 'selected' : ''}>Minutes</option>
+                        <option value="hours" ${SettingsForms.secondsToValueUnit(settings.sleep_duration !== undefined ? settings.sleep_duration : 900).unit === 'hours' ? 'selected' : ''}>Hours</option>
+                        <option value="days" ${SettingsForms.secondsToValueUnit(settings.sleep_duration !== undefined ? settings.sleep_duration : 900).unit === 'days' ? 'selected' : ''}>Days</option>
+                    </select>
+                    <p class="setting-help">Time between processing cycles</p>
                 </div>
                 <div class="setting-item">
                     <label for="eros_hourly_cap"><a href="#" class="info-icon" title="Maximum API requests per hour for this app" target="_blank" rel="noopener"><i class="fas fa-info-circle"></i></a>API Cap - Hourly:</label>
@@ -942,6 +972,14 @@ const SettingsForms = {
             } else {
                 return element.value || defaultValue;
             }
+        }
+
+        function getDurationSeconds(valueSelector, unitSelector, defaultSeconds) {
+            const value = getInputValue(valueSelector, null);
+            const unitElement = container.querySelector(unitSelector);
+            const unit = unitElement ? unitElement.value : 'minutes';
+            if (value === null || isNaN(value)) return defaultSeconds;
+            return SettingsForms.valueUnitToSeconds(value, unit);
         }
         
         // For the general settings form, collect settings including advanced settings
@@ -1070,7 +1108,7 @@ const SettingsForms = {
                 settings.upgrade_mode = getInputValue('#sonarr-upgrade-mode', 'seasons_packs');
                 settings.hunt_missing_items = getInputValue('#sonarr-hunt-missing-items', 1);
                 settings.hunt_upgrade_items = getInputValue('#sonarr-hunt-upgrade-items', 0);
-                settings.sleep_duration = getInputValue('#sonarr_sleep_duration', 900);
+                settings.sleep_duration = getDurationSeconds('#sonarr_sleep_duration', '#sonarr_sleep_duration_unit', 900);
                 settings.hourly_cap = getInputValue('#sonarr_hourly_cap', 20);
                 settings.monitored_only = getInputValue('#sonarr_monitored_only', true);
                 settings.skip_future_episodes = getInputValue('#sonarr_skip_future_episodes', true);
@@ -1080,7 +1118,7 @@ const SettingsForms = {
             else if (appType === 'radarr') {
                 settings.hunt_missing_movies = getInputValue('#radarr_hunt_missing_movies', 1);
                 settings.hunt_upgrade_movies = getInputValue('#radarr_hunt_upgrade_movies', 0);
-                settings.sleep_duration = getInputValue('#radarr_sleep_duration', 900);
+                settings.sleep_duration = getDurationSeconds('#radarr_sleep_duration', '#radarr_sleep_duration_unit', 900);
                 settings.hourly_cap = getInputValue('#radarr_hourly_cap', 20);
                 settings.monitored_only = getInputValue('#radarr_monitored_only', true);
                 settings.skip_future_releases = getInputValue('#radarr_skip_future_releases', true);
@@ -1093,7 +1131,7 @@ const SettingsForms = {
                 settings.hunt_upgrade_items = getInputValue('#lidarr_hunt_upgrade_items', 0);
                 settings.hunt_missing_mode = getInputValue('#lidarr_hunt_missing_mode', 'album');
                 settings.monitored_only = getInputValue('#lidarr_monitored_only', true);
-                settings.sleep_duration = getInputValue('#lidarr_sleep_duration', 900);
+                settings.sleep_duration = getDurationSeconds('#lidarr_sleep_duration', '#lidarr_sleep_duration_unit', 900);
                 settings.hourly_cap = getInputValue('#lidarr_hourly_cap', 20);
                 settings.tag_processed_items = getInputValue('#lidarr_tag_processed_items', true);
             } 
@@ -1104,7 +1142,7 @@ const SettingsForms = {
                 settings.skip_future_releases = getInputValue('#readarr_skip_future_releases', true);
                 settings.tag_processed_items = getInputValue('#readarr_tag_processed_items', true);
 
-                settings.sleep_duration = getInputValue('#readarr_sleep_duration', 900);
+                settings.sleep_duration = getDurationSeconds('#readarr_sleep_duration', '#readarr_sleep_duration_unit', 900);
                 settings.hourly_cap = getInputValue('#readarr_hourly_cap', 20);
             } 
             else if (appType === 'whisparr') {
@@ -1115,7 +1153,7 @@ const SettingsForms = {
                 settings.skip_future_releases = getInputValue('#whisparr_skip_future_releases', true);
                 settings.tag_processed_items = getInputValue('#whisparr_tag_processed_items', true);
 
-                settings.sleep_duration = getInputValue('#whisparr_sleep_duration', 900);
+                settings.sleep_duration = getDurationSeconds('#whisparr_sleep_duration', '#whisparr_sleep_duration_unit', 900);
                 settings.hourly_cap = getInputValue('#whisparr_hourly_cap', 20);
             }
             else if (appType === 'eros') {
@@ -1126,7 +1164,7 @@ const SettingsForms = {
                 settings.skip_future_releases = getInputValue('#eros_skip_future_releases', true);
                 settings.tag_processed_items = getInputValue('#eros_tag_processed_items', true);
 
-                settings.sleep_duration = getInputValue('#eros_sleep_duration', 900);
+                settings.sleep_duration = getDurationSeconds('#eros_sleep_duration', '#eros_sleep_duration_unit', 900);
                 settings.hourly_cap = getInputValue('#eros_hourly_cap', 20);
             }
         }
@@ -1383,30 +1421,52 @@ const SettingsForms = {
     
     // Update duration display - e.g., convert seconds to hours
     updateDurationDisplay: function() {
-        // Function to update a specific sleep duration display
-        const updateSleepDisplay = function(inputId, spanId) {
+        const updateSleepDisplay = function(inputId, unitId, spanId) {
             const input = document.getElementById(inputId);
+            const unit = document.getElementById(unitId);
             const span = document.getElementById(spanId);
-            if (!input || !span) return;
-            
-            const seconds = parseInt(input.value);
-            if (isNaN(seconds)) return;
-            
+            if (!input || !unit || !span) return;
+
+            const value = parseInt(input.value);
+            if (isNaN(value)) return;
+
+            const seconds = SettingsForms.valueUnitToSeconds(value, unit.value);
             const hours = (seconds / 3600).toFixed(1);
-            if (hours < 1) {
-                const minutes = Math.round(seconds / 60);
-                span.textContent = `${minutes} minutes`;
+            if (seconds % 86400 === 0) {
+                span.textContent = `${(seconds / 86400).toFixed(1)} days`;
+            } else if (hours < 1) {
+                span.textContent = `${Math.round(seconds / 60)} minutes`;
             } else {
                 span.textContent = `${hours} hours`;
             }
         };
 
-        // Update for each app
-        updateSleepDisplay('sleep_duration', 'sleep_duration_hours');
-        updateSleepDisplay('radarr_sleep_duration', 'radarr_sleep_duration_hours');
-        updateSleepDisplay('lidarr_sleep_duration', 'lidarr_sleep_duration_hours');
-        updateSleepDisplay('readarr_sleep_duration', 'readarr_sleep_duration_hours');
-        updateSleepDisplay('whisparr_sleep_duration', 'whisparr_sleep_duration_hours'); // Added Whisparr
+        updateSleepDisplay('sonarr_sleep_duration', 'sonarr_sleep_duration_unit', 'sleep_duration_hours');
+        updateSleepDisplay('radarr_sleep_duration', 'radarr_sleep_duration_unit', 'radarr_sleep_duration_hours');
+        updateSleepDisplay('lidarr_sleep_duration', 'lidarr_sleep_duration_unit', 'lidarr_sleep_duration_hours');
+        updateSleepDisplay('readarr_sleep_duration', 'readarr_sleep_duration_unit', 'readarr_sleep_duration_hours');
+        updateSleepDisplay('whisparr_sleep_duration', 'whisparr_sleep_duration_unit', 'whisparr_sleep_duration_hours');
+        updateSleepDisplay('eros_sleep_duration', 'eros_sleep_duration_unit', 'eros_sleep_duration_hours');
+    },
+
+    // Convert seconds to a value and unit for display
+    secondsToValueUnit: function(seconds) {
+        let unit = 'minutes';
+        let value = Math.round(seconds / 60);
+        if (seconds % 86400 === 0) {
+            unit = 'days';
+            value = seconds / 86400;
+        } else if (seconds % 3600 === 0) {
+            unit = 'hours';
+            value = seconds / 3600;
+        }
+        return { value, unit };
+    },
+
+    // Convert a value and unit to seconds
+    valueUnitToSeconds: function(value, unit) {
+        const multiplier = unit === 'days' ? 86400 : unit === 'hours' ? 3600 : 60;
+        return value * multiplier;
     },
     
     // Setup instance management - test connection buttons and add/remove instance buttons


### PR DESCRIPTION
## Summary
- add value/unit dropdown for sleep duration settings
- convert unit selections to seconds when saving
- document sleep duration in minutes/hours/days

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684267d5c8e883288a3170e3115702b9