### PR TITLE
Improve sleep duration UI

### DIFF
--- a/docs/apps/lidarr.html
+++ b/docs/apps/lidarr.html
@@ -147,7 +147,7 @@
                 </tr>
                 <tr>
                     <td>Sleep Duration</td>
-                    <td>Time in seconds between processing cycles</td>
+                    <td>Time between processing cycles</td>
                     <td>1800 (30 min)</td>
                     <td>Music indexers often have stricter limits</td>
                 </tr>

--- a/docs/apps/radarr.html
+++ b/docs/apps/radarr.html
@@ -145,7 +145,7 @@
                 </tr>
                 <tr>
                     <td>Sleep Duration</td>
-                    <td>Time in seconds between processing cycles</td>
+                    <td>Time between processing cycles</td>
                     <td>1200 (20 min)</td>
                     <td>Longer intervals reduce indexer load</td>
                 </tr>

--- a/docs/apps/readarr.html
+++ b/docs/apps/readarr.html
@@ -147,7 +147,7 @@
                 </tr>
                 <tr>
                     <td>Sleep Duration</td>
-                    <td>Time in seconds between processing cycles</td>
+                    <td>Time between processing cycles</td>
                     <td>2400 (40 min)</td>
                     <td>Book indexers often have limited content</td>
                 </tr>

--- a/docs/apps/sonarr.html
+++ b/docs/apps/sonarr.html
@@ -154,7 +154,7 @@
                 </tr>
                 <tr>
                     <td>Sleep Duration</td>
-                    <td>Time in seconds between processing cycles</td>
+                    <td>Time between processing cycles</td>
                     <td>900 (15 min)</td>
                     <td>Longer intervals reduce indexer load</td>
                 </tr>

--- a/docs/apps/whisparr-v2.html
+++ b/docs/apps/whisparr-v2.html
@@ -151,7 +151,7 @@
                 </tr>
                 <tr>
                     <td>Sleep Duration</td>
-                    <td>Time in seconds between processing cycles</td>
+                    <td>Time between processing cycles</td>
                     <td>3600 (60 min)</td>
                     <td>Adult indexers often have strict limits</td>
                 </tr>

--- a/docs/apps/whisparr-v3.html
+++ b/docs/apps/whisparr-v3.html
@@ -153,7 +153,7 @@
                 </tr>
                 <tr>
                     <td>Sleep Duration</td>
-                    <td>Time in seconds between processing cycles</td>
+                    <td>Time between processing cycles</td>
                     <td>3600 (60 min)</td>
                     <td>Adult indexers often have strict limits</td>
                 </tr>

--- a/docs/faq.html
+++ b/docs/faq.html
@@ -184,7 +184,7 @@
                     <div class="faq-answer">
                         In the web interface settings, you can configure:
                         <ul>
-                            <li><strong>Sleep Duration:</strong> Time between search cycles (default: 900 seconds)</li>
+                            <li><strong>Sleep Duration:</strong> Time between search cycles (enter days, hours, minutes, and seconds; default: 15 minutes)</li>
                             <li><strong>Hunt Missing:</strong> Number of missing items to search per cycle</li>
                             <li><strong>Hunt Upgrades:</strong> Number of upgrade searches per cycle</li>
                             <li><strong>Minimum Download Queue Size:</strong> Pause searching when queue exceeds this number</li>

--- a/frontend/static/css/new-style.css
+++ b/frontend/static/css/new-style.css
@@ -2276,6 +2276,23 @@ input[type="number"].interval-input,
     padding: 12px 8px !important;
 }
 
+/* Grouped duration inputs */
+.duration-inputs {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    flex-wrap: wrap;
+}
+
+.duration-inputs input {
+    text-align: center;
+}
+
+.duration-inputs span {
+    color: var(--text-primary);
+    margin-right: 4px;
+}
+
 /* Stateful management header row with reset button */
 .stateful-header-row {
     display: flex;

--- a/frontend/static/js/settings_forms.js
+++ b/frontend/static/js/settings_forms.js
@@ -111,9 +111,14 @@ const SettingsForms = {
                     <p class="setting-help">Number of episodes to upgrade per cycle (0 to disable)</p>
                 </div>
                 <div class="setting-item">
-                    <label for="sonarr_sleep_duration"><a href="/Huntarr.io/docs/#/configuration?id=sleep-duration" class="info-icon" title="Learn more about sleep duration" target="_blank" rel="noopener"><i class="fas fa-info-circle"></i></a>Sleep Duration:</label>
-                    <input type="number" id="sonarr_sleep_duration" name="sleep_duration" min="60" value="${settings.sleep_duration !== undefined ? settings.sleep_duration : 900}">
-                    <p class="setting-help">Time in seconds between processing cycles</p>
+                    <label for="sonarr_sleep_seconds"><a href="/Huntarr.io/docs/#/configuration?id=sleep-duration" class="info-icon" title="Learn more about sleep duration" target="_blank" rel="noopener"><i class="fas fa-info-circle"></i></a>Sleep Duration:</label>
+                    <div class="duration-inputs">
+                        <input type="number" id="sonarr_sleep_seconds" class="short-number-input interval-input" min="0" value="${SettingsForms.secondsToParts(settings.sleep_duration !== undefined ? settings.sleep_duration : 900).seconds}"><span>Seconds</span>
+                        <input type="number" id="sonarr_sleep_minutes" class="short-number-input interval-input" min="0" value="${SettingsForms.secondsToParts(settings.sleep_duration !== undefined ? settings.sleep_duration : 900).minutes}"><span>Minutes</span>
+                        <input type="number" id="sonarr_sleep_hours" class="short-number-input interval-input" min="0" value="${SettingsForms.secondsToParts(settings.sleep_duration !== undefined ? settings.sleep_duration : 900).hours}"><span>Hours</span>
+                        <input type="number" id="sonarr_sleep_days" class="short-number-input interval-input" min="0" value="${SettingsForms.secondsToParts(settings.sleep_duration !== undefined ? settings.sleep_duration : 900).days}"><span>Days</span>
+                    </div>
+                    <p class="setting-help">Time between processing cycles</p>
                 </div>
                 <div class="setting-item">
                     <label for="sonarr_hourly_cap"><a href="#" class="info-icon" title="Maximum API requests per hour for this app" target="_blank" rel="noopener"><i class="fas fa-info-circle"></i></a>API Cap - Hourly:</label>
@@ -274,9 +279,14 @@ const SettingsForms = {
                     <p class="setting-help">Number of movies to search for quality upgrades per cycle (0 to disable)</p>
                 </div>
                 <div class="setting-item">
-                    <label for="radarr_sleep_duration"><a href="/Huntarr.io/docs/#/configuration?id=sleep-duration" class="info-icon" title="Learn more about sleep duration" target="_blank" rel="noopener"><i class="fas fa-info-circle"></i></a>Sleep Duration:</label>
-                    <input type="number" id="radarr_sleep_duration" name="sleep_duration" min="60" value="${settings.sleep_duration !== undefined ? settings.sleep_duration : 900}">
-                    <p class="setting-help">Time in seconds between processing cycles</p>
+                    <label for="radarr_sleep_seconds"><a href="/Huntarr.io/docs/#/configuration?id=sleep-duration" class="info-icon" title="Learn more about sleep duration" target="_blank" rel="noopener"><i class="fas fa-info-circle"></i></a>Sleep Duration:</label>
+                    <div class="duration-inputs">
+                        <input type="number" id="radarr_sleep_seconds" class="short-number-input interval-input" min="0" value="${SettingsForms.secondsToParts(settings.sleep_duration !== undefined ? settings.sleep_duration : 900).seconds}"><span>Seconds</span>
+                        <input type="number" id="radarr_sleep_minutes" class="short-number-input interval-input" min="0" value="${SettingsForms.secondsToParts(settings.sleep_duration !== undefined ? settings.sleep_duration : 900).minutes}"><span>Minutes</span>
+                        <input type="number" id="radarr_sleep_hours" class="short-number-input interval-input" min="0" value="${SettingsForms.secondsToParts(settings.sleep_duration !== undefined ? settings.sleep_duration : 900).hours}"><span>Hours</span>
+                        <input type="number" id="radarr_sleep_days" class="short-number-input interval-input" min="0" value="${SettingsForms.secondsToParts(settings.sleep_duration !== undefined ? settings.sleep_duration : 900).days}"><span>Days</span>
+                    </div>
+                    <p class="setting-help">Time between processing cycles</p>
                 </div>
                 <div class="setting-item">
                     <label for="radarr_hourly_cap"><a href="#" class="info-icon" title="Maximum API requests per hour for this app" target="_blank" rel="noopener"><i class="fas fa-info-circle"></i></a>API Cap - Hourly:</label>
@@ -443,9 +453,14 @@ const SettingsForms = {
                     <p class="setting-help">Number of albums to search for quality upgrades per cycle (0 to disable)</p>
                 </div>
                 <div class="setting-item">
-                    <label for="lidarr_sleep_duration"><a href="/Huntarr.io/docs/#/configuration?id=sleep-duration" class="info-icon" title="Learn more about sleep duration" target="_blank" rel="noopener"><i class="fas fa-info-circle"></i></a>Sleep Duration:</label>
-                    <input type="number" id="lidarr_sleep_duration" name="sleep_duration" min="60" value="${settings.sleep_duration !== undefined ? settings.sleep_duration : 900}">
-                    <p class="setting-help">Time in seconds between processing cycles</p>
+                    <label for="lidarr_sleep_seconds"><a href="/Huntarr.io/docs/#/configuration?id=sleep-duration" class="info-icon" title="Learn more about sleep duration" target="_blank" rel="noopener"><i class="fas fa-info-circle"></i></a>Sleep Duration:</label>
+                    <div class="duration-inputs">
+                        <input type="number" id="lidarr_sleep_seconds" class="short-number-input interval-input" min="0" value="${SettingsForms.secondsToParts(settings.sleep_duration !== undefined ? settings.sleep_duration : 900).seconds}"><span>Seconds</span>
+                        <input type="number" id="lidarr_sleep_minutes" class="short-number-input interval-input" min="0" value="${SettingsForms.secondsToParts(settings.sleep_duration !== undefined ? settings.sleep_duration : 900).minutes}"><span>Minutes</span>
+                        <input type="number" id="lidarr_sleep_hours" class="short-number-input interval-input" min="0" value="${SettingsForms.secondsToParts(settings.sleep_duration !== undefined ? settings.sleep_duration : 900).hours}"><span>Hours</span>
+                        <input type="number" id="lidarr_sleep_days" class="short-number-input interval-input" min="0" value="${SettingsForms.secondsToParts(settings.sleep_duration !== undefined ? settings.sleep_duration : 900).days}"><span>Days</span>
+                    </div>
+                    <p class="setting-help">Time between processing cycles</p>
                 </div>
                 <div class="setting-item">
                     <label for="lidarr_hourly_cap"><a href="#" class="info-icon" title="Maximum API requests per hour for this app" target="_blank" rel="noopener"><i class="fas fa-info-circle"></i></a>API Cap - Hourly:</label>
@@ -578,9 +593,14 @@ const SettingsForms = {
                     <p class="setting-help">Number of books to search for quality upgrades per cycle (0 to disable)</p>
                 </div>
                 <div class="setting-item">
-                    <label for="readarr_sleep_duration"><a href="/Huntarr.io/docs/#/configuration?id=sleep-duration" class="info-icon" title="Learn more about sleep duration" target="_blank" rel="noopener"><i class="fas fa-info-circle"></i></a>Sleep Duration:</label>
-                    <input type="number" id="readarr_sleep_duration" name="sleep_duration" min="60" value="${settings.sleep_duration !== undefined ? settings.sleep_duration : 900}">
-                    <p class="setting-help">Time in seconds between processing cycles</p>
+                    <label for="readarr_sleep_seconds"><a href="/Huntarr.io/docs/#/configuration?id=sleep-duration" class="info-icon" title="Learn more about sleep duration" target="_blank" rel="noopener"><i class="fas fa-info-circle"></i></a>Sleep Duration:</label>
+                    <div class="duration-inputs">
+                        <input type="number" id="readarr_sleep_seconds" class="short-number-input interval-input" min="0" value="${SettingsForms.secondsToParts(settings.sleep_duration !== undefined ? settings.sleep_duration : 900).seconds}"><span>Seconds</span>
+                        <input type="number" id="readarr_sleep_minutes" class="short-number-input interval-input" min="0" value="${SettingsForms.secondsToParts(settings.sleep_duration !== undefined ? settings.sleep_duration : 900).minutes}"><span>Minutes</span>
+                        <input type="number" id="readarr_sleep_hours" class="short-number-input interval-input" min="0" value="${SettingsForms.secondsToParts(settings.sleep_duration !== undefined ? settings.sleep_duration : 900).hours}"><span>Hours</span>
+                        <input type="number" id="readarr_sleep_days" class="short-number-input interval-input" min="0" value="${SettingsForms.secondsToParts(settings.sleep_duration !== undefined ? settings.sleep_duration : 900).days}"><span>Days</span>
+                    </div>
+                    <p class="setting-help">Time between processing cycles</p>
                 </div>
                 <div class="setting-item">
                     <label for="readarr_hourly_cap"><a href="#" class="info-icon" title="Maximum API requests per hour for this app" target="_blank" rel="noopener"><i class="fas fa-info-circle"></i></a>API Cap - Hourly:</label>
@@ -711,9 +731,14 @@ const SettingsForms = {
                     <p class="setting-help">Number of items to search for quality upgrades per cycle (0 to disable)</p>
                 </div>
                 <div class="setting-item">
-                    <label for="whisparr_sleep_duration"><a href="/Huntarr.io/docs/#/configuration?id=sleep-duration" class="info-icon" title="Learn more about sleep duration" target="_blank" rel="noopener"><i class="fas fa-info-circle"></i></a>Sleep Duration:</label>
-                    <input type="number" id="whisparr_sleep_duration" name="sleep_duration" min="60" value="${settings.sleep_duration !== undefined ? settings.sleep_duration : 900}">
-                    <p class="setting-help">Time in seconds between processing cycles</p>
+                    <label for="whisparr_sleep_seconds"><a href="/Huntarr.io/docs/#/configuration?id=sleep-duration" class="info-icon" title="Learn more about sleep duration" target="_blank" rel="noopener"><i class="fas fa-info-circle"></i></a>Sleep Duration:</label>
+                    <div class="duration-inputs">
+                        <input type="number" id="whisparr_sleep_seconds" class="short-number-input interval-input" min="0" value="${SettingsForms.secondsToParts(settings.sleep_duration !== undefined ? settings.sleep_duration : 900).seconds}"><span>Seconds</span>
+                        <input type="number" id="whisparr_sleep_minutes" class="short-number-input interval-input" min="0" value="${SettingsForms.secondsToParts(settings.sleep_duration !== undefined ? settings.sleep_duration : 900).minutes}"><span>Minutes</span>
+                        <input type="number" id="whisparr_sleep_hours" class="short-number-input interval-input" min="0" value="${SettingsForms.secondsToParts(settings.sleep_duration !== undefined ? settings.sleep_duration : 900).hours}"><span>Hours</span>
+                        <input type="number" id="whisparr_sleep_days" class="short-number-input interval-input" min="0" value="${SettingsForms.secondsToParts(settings.sleep_duration !== undefined ? settings.sleep_duration : 900).days}"><span>Days</span>
+                    </div>
+                    <p class="setting-help">Time between processing cycles</p>
                 </div>
                 <div class="setting-item">
                     <label for="whisparr_hourly_cap"><a href="#" class="info-icon" title="Maximum API requests per hour for this app" target="_blank" rel="noopener"><i class="fas fa-info-circle"></i></a>API Cap - Hourly:</label>
@@ -858,9 +883,14 @@ const SettingsForms = {
                     <p class="setting-help">Number of items to search for quality upgrades per cycle (0 to disable)</p>
                 </div>
                 <div class="setting-item">
-                    <label for="eros_sleep_duration"><a href="/Huntarr.io/docs/#/configuration?id=sleep-duration" class="info-icon" title="Learn more about sleep duration" target="_blank" rel="noopener"><i class="fas fa-info-circle"></i></a>Sleep Duration:</label>
-                    <input type="number" id="eros_sleep_duration" name="sleep_duration" min="60" value="${settings.sleep_duration !== undefined ? settings.sleep_duration : 900}">
-                    <p class="setting-help">Time in seconds between processing cycles</p>
+                    <label for="eros_sleep_seconds"><a href="/Huntarr.io/docs/#/configuration?id=sleep-duration" class="info-icon" title="Learn more about sleep duration" target="_blank" rel="noopener"><i class="fas fa-info-circle"></i></a>Sleep Duration:</label>
+                    <div class="duration-inputs">
+                        <input type="number" id="eros_sleep_seconds" class="short-number-input interval-input" min="0" value="${SettingsForms.secondsToParts(settings.sleep_duration !== undefined ? settings.sleep_duration : 900).seconds}"><span>Seconds</span>
+                        <input type="number" id="eros_sleep_minutes" class="short-number-input interval-input" min="0" value="${SettingsForms.secondsToParts(settings.sleep_duration !== undefined ? settings.sleep_duration : 900).minutes}"><span>Minutes</span>
+                        <input type="number" id="eros_sleep_hours" class="short-number-input interval-input" min="0" value="${SettingsForms.secondsToParts(settings.sleep_duration !== undefined ? settings.sleep_duration : 900).hours}"><span>Hours</span>
+                        <input type="number" id="eros_sleep_days" class="short-number-input interval-input" min="0" value="${SettingsForms.secondsToParts(settings.sleep_duration !== undefined ? settings.sleep_duration : 900).days}"><span>Days</span>
+                    </div>
+                    <p class="setting-help">Time between processing cycles</p>
                 </div>
                 <div class="setting-item">
                     <label for="eros_hourly_cap"><a href="#" class="info-icon" title="Maximum API requests per hour for this app" target="_blank" rel="noopener"><i class="fas fa-info-circle"></i></a>API Cap - Hourly:</label>
@@ -942,6 +972,15 @@ const SettingsForms = {
             } else {
                 return element.value || defaultValue;
             }
+        }
+
+        function getDurationSecondsFromParts(prefix, defaultSeconds) {
+            const sec = getInputValue(`#${prefix}_sleep_seconds`, 0);
+            const min = getInputValue(`#${prefix}_sleep_minutes`, 0);
+            const hr  = getInputValue(`#${prefix}_sleep_hours`, 0);
+            const day = getInputValue(`#${prefix}_sleep_days`, 0);
+            if ([sec, min, hr, day].every(v => v === null)) return defaultSeconds;
+            return SettingsForms.partsToSeconds({ seconds: sec || 0, minutes: min || 0, hours: hr || 0, days: day || 0 });
         }
         
         // For the general settings form, collect settings including advanced settings
@@ -1070,7 +1109,7 @@ const SettingsForms = {
                 settings.upgrade_mode = getInputValue('#sonarr-upgrade-mode', 'seasons_packs');
                 settings.hunt_missing_items = getInputValue('#sonarr-hunt-missing-items', 1);
                 settings.hunt_upgrade_items = getInputValue('#sonarr-hunt-upgrade-items', 0);
-                settings.sleep_duration = getInputValue('#sonarr_sleep_duration', 900);
+                settings.sleep_duration = getDurationSecondsFromParts('sonarr', 900);
                 settings.hourly_cap = getInputValue('#sonarr_hourly_cap', 20);
                 settings.monitored_only = getInputValue('#sonarr_monitored_only', true);
                 settings.skip_future_episodes = getInputValue('#sonarr_skip_future_episodes', true);
@@ -1080,7 +1119,7 @@ const SettingsForms = {
             else if (appType === 'radarr') {
                 settings.hunt_missing_movies = getInputValue('#radarr_hunt_missing_movies', 1);
                 settings.hunt_upgrade_movies = getInputValue('#radarr_hunt_upgrade_movies', 0);
-                settings.sleep_duration = getInputValue('#radarr_sleep_duration', 900);
+                settings.sleep_duration = getDurationSecondsFromParts('radarr', 900);
                 settings.hourly_cap = getInputValue('#radarr_hourly_cap', 20);
                 settings.monitored_only = getInputValue('#radarr_monitored_only', true);
                 settings.skip_future_releases = getInputValue('#radarr_skip_future_releases', true);
@@ -1093,7 +1132,7 @@ const SettingsForms = {
                 settings.hunt_upgrade_items = getInputValue('#lidarr_hunt_upgrade_items', 0);
                 settings.hunt_missing_mode = getInputValue('#lidarr_hunt_missing_mode', 'album');
                 settings.monitored_only = getInputValue('#lidarr_monitored_only', true);
-                settings.sleep_duration = getInputValue('#lidarr_sleep_duration', 900);
+                settings.sleep_duration = getDurationSecondsFromParts('lidarr', 900);
                 settings.hourly_cap = getInputValue('#lidarr_hourly_cap', 20);
                 settings.tag_processed_items = getInputValue('#lidarr_tag_processed_items', true);
             } 
@@ -1104,7 +1143,7 @@ const SettingsForms = {
                 settings.skip_future_releases = getInputValue('#readarr_skip_future_releases', true);
                 settings.tag_processed_items = getInputValue('#readarr_tag_processed_items', true);
 
-                settings.sleep_duration = getInputValue('#readarr_sleep_duration', 900);
+                settings.sleep_duration = getDurationSecondsFromParts('readarr', 900);
                 settings.hourly_cap = getInputValue('#readarr_hourly_cap', 20);
             } 
             else if (appType === 'whisparr') {
@@ -1115,7 +1154,7 @@ const SettingsForms = {
                 settings.skip_future_releases = getInputValue('#whisparr_skip_future_releases', true);
                 settings.tag_processed_items = getInputValue('#whisparr_tag_processed_items', true);
 
-                settings.sleep_duration = getInputValue('#whisparr_sleep_duration', 900);
+                settings.sleep_duration = getDurationSecondsFromParts('whisparr', 900);
                 settings.hourly_cap = getInputValue('#whisparr_hourly_cap', 20);
             }
             else if (appType === 'eros') {
@@ -1126,7 +1165,7 @@ const SettingsForms = {
                 settings.skip_future_releases = getInputValue('#eros_skip_future_releases', true);
                 settings.tag_processed_items = getInputValue('#eros_tag_processed_items', true);
 
-                settings.sleep_duration = getInputValue('#eros_sleep_duration', 900);
+                settings.sleep_duration = getDurationSecondsFromParts('eros', 900);
                 settings.hourly_cap = getInputValue('#eros_hourly_cap', 20);
             }
         }
@@ -1383,30 +1422,54 @@ const SettingsForms = {
     
     // Update duration display - e.g., convert seconds to hours
     updateDurationDisplay: function() {
-        // Function to update a specific sleep duration display
-        const updateSleepDisplay = function(inputId, spanId) {
-            const input = document.getElementById(inputId);
+        const updateSleepDisplay = function(prefix, spanId) {
+            const sec = document.getElementById(prefix + '_sleep_seconds');
+            const min = document.getElementById(prefix + '_sleep_minutes');
+            const hr = document.getElementById(prefix + '_sleep_hours');
+            const day = document.getElementById(prefix + '_sleep_days');
             const span = document.getElementById(spanId);
-            if (!input || !span) return;
-            
-            const seconds = parseInt(input.value);
-            if (isNaN(seconds)) return;
-            
+            if (!sec || !min || !hr || !day || !span) return;
+
+            const parts = {
+                seconds: parseInt(sec.value) || 0,
+                minutes: parseInt(min.value) || 0,
+                hours: parseInt(hr.value) || 0,
+                days: parseInt(day.value) || 0
+            };
+            const seconds = SettingsForms.partsToSeconds(parts);
             const hours = (seconds / 3600).toFixed(1);
-            if (hours < 1) {
-                const minutes = Math.round(seconds / 60);
-                span.textContent = `${minutes} minutes`;
+            if (seconds % 86400 === 0) {
+                span.textContent = `${(seconds / 86400).toFixed(1)} days`;
+            } else if (hours < 1) {
+                span.textContent = `${Math.round(seconds / 60)} minutes`;
             } else {
                 span.textContent = `${hours} hours`;
             }
         };
 
-        // Update for each app
-        updateSleepDisplay('sleep_duration', 'sleep_duration_hours');
-        updateSleepDisplay('radarr_sleep_duration', 'radarr_sleep_duration_hours');
-        updateSleepDisplay('lidarr_sleep_duration', 'lidarr_sleep_duration_hours');
-        updateSleepDisplay('readarr_sleep_duration', 'readarr_sleep_duration_hours');
-        updateSleepDisplay('whisparr_sleep_duration', 'whisparr_sleep_duration_hours'); // Added Whisparr
+        updateSleepDisplay('sonarr', 'sleep_duration_hours');
+        updateSleepDisplay('radarr', 'radarr_sleep_duration_hours');
+        updateSleepDisplay('lidarr', 'lidarr_sleep_duration_hours');
+        updateSleepDisplay('readarr', 'readarr_sleep_duration_hours');
+        updateSleepDisplay('whisparr', 'whisparr_sleep_duration_hours');
+        updateSleepDisplay('eros', 'eros_sleep_duration_hours');
+    },
+
+    // Convert seconds to individual parts
+    secondsToParts: function(totalSeconds) {
+        const days = Math.floor(totalSeconds / 86400);
+        totalSeconds %= 86400;
+        const hours = Math.floor(totalSeconds / 3600);
+        totalSeconds %= 3600;
+        const minutes = Math.floor(totalSeconds / 60);
+        const seconds = totalSeconds % 60;
+        return { days, hours, minutes, seconds };
+    },
+
+    // Convert parts back to seconds
+    partsToSeconds: function(parts) {
+        return (parts.days * 86400) + (parts.hours * 3600) +
+               (parts.minutes * 60) + (parts.seconds);
     },
     
     // Setup instance management - test connection buttons and add/remove instance buttons


### PR DESCRIPTION
## Summary
- add separate fields for seconds, minutes, hours and days
- convert the combined values back to seconds when saving
- tweak styles for new grouped inputs
- clarify docs about entering days/hours/minutes/seconds

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684267d5c8e883288a3170e3115702b9